### PR TITLE
Changed header background color

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -2,7 +2,7 @@
 
 /* Light mode header */
 .header {
-    background: #e4e7e2;
+    background: #ffffff;
     padding-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
#52 issue: Theme toggle button partially invisible in light mode compared to dark mode  

I have changed the background color of the header in the light mode so that the toggle button could be visible. 
<img width="204" alt="Screenshot 2025-02-10 at 12 28 30 AM" src="https://github.com/user-attachments/assets/ebf7de72-5886-4079-81e5-b174a9fce0ae" />
