### PR TITLE
Rewrite print_metadata.py for Python 3.14

### DIFF
--- a/content/english/about/process.md
+++ b/content/english/about/process.md
@@ -35,7 +35,7 @@ As a PyPodcats team member, you should have access to the following:
 Credentials for the above are found on Notion.
 
 Tools that are needed for the **"Publishing"** step:
-- Python
+- Python 3.14 or newer
 - [ffmpeg](https://www.ffmpeg.org/ffmpeg.html)
 - [ffprobe](https://www.ffmpeg.org/ffprobe.html)
 - [Hugo](https://gohugo.io/) static site generator
@@ -218,19 +218,9 @@ The fields should be self-explanatory (hopefully), but here are some fields that
 
 ##### Printing the metadata using Python
 
-Create and activate a virtual environment.
-
-```
-python3 -m venv venv
-source venv/bin/activate
-```
-
-Install the dependencies:
-
-```
-pip install -U pip
-pip install -r requirements.txt
-```
+The script requires Python 3.14 or newer and the ffprobe command line tool. It uses
+only the Python standard library, so there are no dependencies to install and no
+virtual environment is needed.
 
 From the root of this repository, run the script:
 

--- a/print_metadata.py
+++ b/print_metadata.py
@@ -1,9 +1,7 @@
 import argparse
+import json
 import os
-
-from ffprobe import FFProbe
-
-
+import subprocess
 
 parser = argparse.ArgumentParser(description='Get Podcast Metadata')
 parser.add_argument('filepath',
@@ -25,10 +23,12 @@ class MetadataProcessor():
       return file_stats.st_size
 
   def get_audio_length(self):
-    metadata = FFProbe(self.filepath)
-    for stream in metadata.streams:
-      return stream.duration_seconds()
-    return 0
+    result = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+         "-of", "json", self.filepath],
+        capture_output=True, text=True, check=True)
+    metadata = json.loads(result.stdout)
+    return float(metadata["format"]["duration"])
 
 if __name__ == "__main__":
     my_args = parser.parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-ffmpeg==1.4
-ffprobe-python==1.0.3


### PR DESCRIPTION
The script crashed on current Python versions because the ffprobe-python package imports the pipes module, which was removed in Python 3.13.

- Call the ffprobe command line tool directly through subprocess and parse its JSON output
- The script now uses only the standard library, so requirements.txt is removed
- Documented in the process page that Python 3.14 or newer is required and that no virtual environment or pip install is needed anymore

Verified against episode 10's audio: output matches the committed frontmatter exactly (podcast_bytes 43942271, podcast_duration 2751.085714).