### PR TITLE
Add proofreading step to the publishing workflow

### DIFF
--- a/content/english/about/process.md
+++ b/content/english/about/process.md
@@ -105,6 +105,7 @@ Tools that are needed for the **"Publishing"** step:
 - Review the generated subtitle, listen to the video, and make edits.
   - fix any typos, especially speaker names
   - Ensure proper capitalization, eg PyPodcats, Python, PSF, PyLadies, etc
+    (see the canonical spelling list in the "Proofread the write-ups" step under Publishing)
   - If necessary, clarify spellings with the speaker.
 - Ensure the subtitle is readable on the video
   - The subtitle text should have black background
@@ -138,6 +139,16 @@ Tools that are needed for the **"Publishing"** step:
     - **f"static/audio/transcript/hidden-figures-of-pyhon-ep{number}.srt:"**: transcript of the full episode
   - Commit, push, and create a pull request
   - Example Pull request: https://github.com/psf/the-invisibles/pull/40
+- Proofread the write-ups before publishing
+  - Run the article through a grammar and spelling checker. Use your browser's spell checker or a
+    grammar checking tool of your choice, or ask a teammate to read it over.
+  - Check that community names use their canonical spelling and capitalization. Some examples:
+    - **Python**, always with a capital P
+    - **PyCon**, always with a capital P and capital C
+    - **PyPodcats**, **PyLadies**, **PSF**, **SciPy**, **NumPy**
+    - **GitHub**, **YouTube**, **TikTok**
+  - Double check the spelling of the speaker's name and the projects they mention,
+    matching the Speaker Info Form
 - Preview the episode (check the Netlify Deploy Preview), share the preview with teammates and speaker
 - Validate the RSS feed format
   - Once Netlify preview has been built, go to {netlify preview url}/episodes/index.xml. This is the RSS Feed url.

--- a/content/english/episodes/ep-11.md
+++ b/content/english/episodes/ep-11.md
@@ -58,7 +58,7 @@ We interviewed Sheena O'Connell.
 
 Sheena began her career as a software engineer and technical leader across multiple startups, but her passion for education led her to spend the last five years reimagining how people learn to code professionally. Working within the nonprofit sector, she built alternative education systems from the ground up and developed deep expertise in effective teaching, educator development, and the structural limitations of traditional education models. Sheena is the founder of Prelude.tech, where she delivers rigorous technical training alongside consultation and coaching for technical educators and organizations with education functions. She also leads the Guild of Educators, a community she founded to empower technology educators through shared resources, support, and evidence-based teaching practices.
 
-In this episode, Sheena O'Connell tells us about her journey, the importance of community and good practices for teachers and educators in python, organizational psychology and how herself has become involve in this journey. We talk about how to enable a 10 x team and how to enable the community through [guild of educators](https://guildofeducators.org/).
+In this episode, Sheena O'Connell tells us about her journey, the importance of community and good practices for teachers and educators in Python, organizational psychology and how she herself became involved in this journey. We talk about how to enable a 10x team and how to enable the community through the [Guild of Educators](https://guildofeducators.org/).
 
 ## Topic discussed
 
@@ -66,12 +66,12 @@ In this episode, Sheena O'Connell tells us about her journey, the importance of 
 - Getting to know Sheena
 - Her involvement in the community
 - Sheena's journey and her passion for education
-- Re-implementing effective education system for learning how to code professionaly in python 
-- Importance of communiy 
+- Re-implementing an effective education system for learning how to code professionally in Python
+- Importance of community
 - Organizational psychology
 - PyCon Africa cool badges 
 
 ## Links from the show
 
-- guild of educators: https://guildofeducators.org/
+- Guild of Educators: https://guildofeducators.org/
 


### PR DESCRIPTION
Adds a "Proofread the write-ups" step to the Publishing section of the process page:

- Run the article through a grammar and spelling checker (browser spell checker, a grammar checking tool of your choice, or a teammate read-through)
- Check canonical spellings: Python (capital P), PyCon (capital P and C), PyPodcats, PyLadies, PSF, SciPy, NumPy, GitHub, YouTube, TikTok
- Double check speaker and project names against the Speaker Info Form
- The Transcribing section now points to this list as well

Also applies the checklist to the Episode 11 write-up as the first pass: professionally, community, Python capitalization, Guild of Educators, and a grammar fix in the intro paragraph.