### PR TITLE
Display a Read Transcript section on episode pages

### DIFF
--- a/content/english/about/process.md
+++ b/content/english/about/process.md
@@ -134,8 +134,11 @@ Tools that are needed for the **"Publishing"** step:
     - **f"content/english/speakers/{speaker_name}.md"** : speaker bio page: photos, links, etc
     - **f"static/audio/hidden-figures-ep{number}-trailer.mp3:"**: mp3 of the trailer
     - **f"static/audio/hidden-figures-ep{number}.mp3:"**: mp3 of the full episode
-    - **f"static/audio/transcript/hidden-figures-of-pyhon-ep{number}-trailer.srt:"**: transcript of the trailer
-    - **f"static/audio/transcript/hidden-figures-of-pyhon-ep{number}.srt:"**: transcript of the full episode
+    - **f"static/transcript/hidden-figures-of-python-ep{number}-trailer.srt:"**: transcript of the trailer
+    - **f"static/transcript/hidden-figures-of-python-ep{number}.srt:"**: transcript of the full episode
+  - The transcript files are displayed on each episode page as a collapsible "Read Transcript" section
+    (right below the video), with a timestamp next to each caption. This is generated automatically from
+    the **transcript** field in the episode frontmatter, so double check that the path is correct.
   - Commit, push, and create a pull request
   - Example Pull request: https://github.com/psf/the-invisibles/pull/40
 - Preview the episode (check the Netlify Deploy Preview), share the preview with teammates and speaker

--- a/themes/hugoplate/layouts/_default/episode.html
+++ b/themes/hugoplate/layouts/_default/episode.html
@@ -37,6 +37,7 @@
           <div class="content mb-10">
             {{ partial "components/podcast-audio-card" . }}
             {{ partial "components/youtube_player" . }}
+            {{ partial "components/transcript" . }}
             {{ .Content }}
             {{ if $.Params.speaker }}
                 <h2>Get to know {{.Params.speaker.Title}}</h2>
@@ -72,7 +73,6 @@
                 </div>
 
             {{ end }}
-            {{ partial "components/transcript" . }}
             {{ partial "components/stay-in-touch" }}
           </div>
 

--- a/themes/hugoplate/layouts/_default/episode.html
+++ b/themes/hugoplate/layouts/_default/episode.html
@@ -36,8 +36,8 @@
 
           <div class="content mb-10">
             {{ partial "components/podcast-audio-card" . }}
-            {{ partial "components/youtube_player" . }}
             {{ partial "components/transcript" . }}
+            {{ partial "components/youtube_player" . }}
             {{ .Content }}
             {{ if $.Params.speaker }}
                 <h2>Get to know {{.Params.speaker.Title}}</h2>

--- a/themes/hugoplate/layouts/_default/episode.html
+++ b/themes/hugoplate/layouts/_default/episode.html
@@ -72,7 +72,7 @@
                 </div>
 
             {{ end }}
-<!--            {{ partial "components/transcript" . }}-->
+            {{ partial "components/transcript" . }}
             {{ partial "components/stay-in-touch" }}
           </div>
 

--- a/themes/hugoplate/layouts/partials/components/podcast-audio-card.html
+++ b/themes/hugoplate/layouts/partials/components/podcast-audio-card.html
@@ -14,7 +14,6 @@
             {{ $caption := .Params.title }}
             <figcaption>{{ $caption }}</figcaption>
             {{ partial "components/podcast-icons"  }}
-            <a href="{{ .Params.transcript | absURL }}"><img src="{{`/images/transcript_icon.png` | relLangURL}}" title="Show Transcript" alt="Show Transcript" class="podcast-icon"/></a>
 
       </h5>
 

--- a/themes/hugoplate/layouts/partials/components/transcript.html
+++ b/themes/hugoplate/layouts/partials/components/transcript.html
@@ -24,7 +24,7 @@
             {{ with trim $text " " }}
               <div class="mb-2 flex">
                 <span class="text-primary dark:text-darkmode-primary mr-4 w-14 flex-none font-mono text-sm leading-6">{{ $start }}</span>
-                <span>{{ . }}</span>
+                <span class="text-text dark:text-darkmode-text">{{ . }}</span>
               </div>
             {{ end }}
           {{ end }}

--- a/themes/hugoplate/layouts/partials/components/transcript.html
+++ b/themes/hugoplate/layouts/partials/components/transcript.html
@@ -1,8 +1,35 @@
-<h5>Transcript</h5>
-{{ $path := print "/static" .Params.transcript }}
-path {{ $path }}
-{{ $file := readFile $path }}
-{{ $file := split $file "\n" }}
-{{ $file := delimit $file "<br>" }}
-<p>{{ $file | safeHTML }}
-</p>
+{{ with .Params.transcript }}
+  {{ $path := print "/static" . }}
+  {{ if fileExists $path }}
+    {{ $content := replace (readFile $path) "\r\n" "\n" }}
+    <details class="bg-theme-light dark:bg-darkmode-theme-light not-prose mb-10 rounded p-6">
+      <summary class="h5 cursor-pointer select-none">
+        <i class="fa-regular fa-file-lines mr-2"></i>Read Transcript
+      </summary>
+      <div class="mt-6 max-h-96 overflow-y-auto pr-2">
+        {{ range split $content "\n\n" }}
+          {{ $lines := split (trim . "\n ") "\n" }}
+          {{ $tsIdx := -1 }}
+          {{ range $i, $line := $lines }}
+            {{ if and (lt $tsIdx 0) (in $line "-->") }}
+              {{ $tsIdx = $i }}
+            {{ end }}
+          {{ end }}
+          {{ if ge $tsIdx 0 }}
+            {{/* "00:01:19,666 --> 00:01:22,066" or VTT "00:01:19.666 --> ..." */}}
+            {{ $start := index (split (index $lines $tsIdx) " ") 0 }}
+            {{ $start = index (split (replace $start "," ".") ".") 0 }}
+            {{ $start = strings.TrimPrefix "00:" $start }}
+            {{ $text := delimit (after (add $tsIdx 1) $lines) " " }}
+            {{ with trim $text " " }}
+              <div class="mb-2 flex">
+                <span class="text-primary dark:text-darkmode-primary mr-4 w-14 flex-none font-mono text-sm leading-6">{{ $start }}</span>
+                <span>{{ . }}</span>
+              </div>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      </div>
+    </details>
+  {{ end }}
+{{ end }}

--- a/themes/hugoplate/layouts/partials/components/transcript.html
+++ b/themes/hugoplate/layouts/partials/components/transcript.html
@@ -3,7 +3,7 @@
   {{ if fileExists $path }}
     {{ $content := replace (readFile $path) "\r\n" "\n" }}
     <details class="bg-theme-light dark:bg-darkmode-theme-light not-prose mb-10 rounded p-6">
-      <summary class="h5 cursor-pointer select-none">
+      <summary class="h5 text-dark dark:text-darkmode-dark cursor-pointer select-none">
         <i class="fa-regular fa-file-lines mr-2"></i>Read Transcript
       </summary>
       <div class="mt-6 max-h-96 overflow-y-auto pr-2">


### PR DESCRIPTION
There was previously no way to read a transcript on the site: the old transcript partial was commented out because it dumped the raw SRT (cue numbers and timestamps included) as one blob, and the audio card had a small transcript icon that linked to the raw .srt file.

This adds a proper transcript display:

- A collapsible "Read Transcript" section on every episode page that has a transcript, placed right after the video and before the write-up
- The SRT (or VTT, used by episodes 1 to 4) is parsed at build time; each caption renders with its start timestamp in a scrollable panel
- Readable in both light and dark mode
- The old transcript icon on the audio card is removed, since this replaces it
- The process page now documents the correct transcript file location (static/transcript/, the doc previously pointed to a nonexistent static/audio/transcript/ path) and how the section is generated from the transcript frontmatter field

Episodes without a transcript file are unaffected, the section simply does not render.

Verified locally against episode 10 (SRT, 1475 cues), episode 1 (VTT), and episode 0.