### PR TITLE
Allow manual runs of the Pages deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,14 @@ on:
   push:
     branches: ["main"]
 
-  # Daily publish at 00:00Z for scheduled posts
+  # Hourly publish for scheduled posts
   schedule:
     - cron: '5 * * * *'
+
+  # Allows running the workflow manually from the Actions tab. This is also
+  # the way to re-run it after GitHub disables the schedule following 60 days
+  # of repository inactivity.
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
The deploy workflow silently stopped in April: GitHub disables scheduled workflows after 60 days of repository inactivity, and while disabled, neither the hourly cron nor push-to-main triggers fire. It has been re-enabled, but there was no way to trigger a deploy manually.

- Add a workflow_dispatch trigger so the workflow can be run from the Actions tab (and so there is an immediate way to redeploy after re-enabling it next time)
- Fix the schedule comment: the cron runs hourly at minute 5, not daily at 00:00Z