### PR TITLE
Remove git conflict markers from Sheena's speaker bio

### DIFF
--- a/content/english/speakers/sheena-oconnell.md
+++ b/content/english/speakers/sheena-oconnell.md
@@ -29,10 +29,8 @@ social:
 
 ---
 
-<<<<<<< add-ep-11-full
-Sheena's early career saw her working as a software engineer and technical leader across multiple startups. But it was her passion for education that led her to devote the last 5+ years to re-imagining how we teach people to code professionally. 
+Sheena's early career saw her working as a software engineer and technical leader across multiple startups. But it was her passion for education that led her to devote the last 5+ years to re-imagining how we teach people to code professionally.
 
-Over the last half decade she has had the opportunity to work in the non-profit space and build alternative education systems from the ground up. Along the way she has learned a lot about how to teach well, how to build organisational systems that teach well, and why traditional education systems fall short. 
+Over the last half decade she has had the opportunity to work in the non-profit space and build alternative education systems from the ground up. Along the way she has learned a lot about how to teach well, how to build organisational systems that teach well, and why traditional education systems fall short.
 
 As a founder of Prelude.tech, she provides rigorous technical training, as well as consultating, and coaching for technical educators, and organisations with education functions (for example grad programs and similar).  Additionally, she leads the Guild of Educators, a community she founded to empower tech educators through shared resources, support, and evidence-based teaching practices.
->>>>>>> main


### PR DESCRIPTION
Sheena's speaker page on production currently renders leftover git conflict markers in her bio (visible at https://pypodcats.live/speakers/sheena-oconnell/, the "<<<<<<< add-ep-11-full" line). The two conflict sides were the same paragraphs, so this removes the markers and the duplicated text.