### PR TITLE
Update the Popular theme to v0.7.0 and add an llms.txt for agents

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -37,6 +37,10 @@ brandSub = "Hidden Figures of Python"
 ogImage = "images/pypodcats-2025-s.png"
 customCSS = ["css/pypodcats.css"]
 
+# The theme sets popularVersion (v0.7.0+) and the footer prints it next to the
+# Popular credit. Blank it so this site's footer keeps just the credit link.
+popularVersion = ""
+
 # Popular theme v0.6.0: SEO knobs
 [seo]
   # Keep FAQPage JSON-LD from {{< faq >}} blocks (default true).

--- a/hugo.toml
+++ b/hugo.toml
@@ -75,7 +75,9 @@ target = '$1'
 
 ############################# Outputs ############################
 [outputs]
-home = ["HTML", "RSS", "WebAppManifest", "SearchIndex"]
+# LLMS emits /llms.txt for AI agents (Popular theme v0.7.0); the format itself
+# comes from the theme, the content from layouts/index.llms.txt.
+home = ["HTML", "RSS", "WebAppManifest", "SearchIndex", "LLMS"]
 section = ['html', 'rss']
 
 ############################# Imaging ############################

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -1,0 +1,31 @@
+{{- /* §8 llms.txt for the podcast layer. The theme's version (themes/popular/
+     layouts/index.llms.txt) is meetup-shaped: it names the next upcoming
+     event and links the iCalendar feed, neither of which exists here. This
+     override answers the questions an agent actually has about a podcast:
+     what the show is, where to listen, and what the latest episodes are.
+     Regenerated every build, so the latest-episode line stays true. */ -}}
+{{- $full := where (where site.RegularPages "Section" "episodes") "Params.episode_type" "!=" "trailer" -}}
+{{- $recent := first 5 $full.ByDate.Reverse -}}
+{{- $latest := index $recent 0 -}}
+# {{ site.Title }}
+{{ with site.Params.description }}
+{{ . }}
+{{ end }}
+{{ with $latest }}Latest episode: {{ .Title }}, published {{ .Date | time.Format ":date_long" }} ({{ .Permalink }}){{ end }}
+
+## Listen and follow
+{{ range site.Params.social }}{{ .label }}: {{ .url | absURL }}
+{{ end }}
+## Recent episodes
+{{ range $recent }}{{- $ep := . -}}- {{ .Title }}, {{ .Date | time.Format ":date_long" }}{{ with .Params.speaker }}{{ if not (in $ep.Title .title) }}, guest {{ .title }}{{ end }}{{ end }} ({{ .Permalink }})
+{{ end }}
+## Links
+All episodes: {{ (site.GetPage "/episodes").Permalink }}
+Guests: {{ (site.GetPage "/speakers").Permalink }}
+Hosts: {{ (site.GetPage (print "/" (partial "section.html" "team"))).Permalink }}
+Blog: {{ (site.GetPage "/blog").Permalink }}
+{{ with site.GetPage "/about" }}About and FAQ: {{ .Permalink }}
+{{ end }}{{ with site.GetPage "/subscribe" }}Subscribe: {{ .Permalink }}
+{{ end }}{{ with site.GetPage "/contact" }}Contact: {{ .Permalink }}
+{{ end }}
+Built with the Popular theme.

--- a/layouts/organizers/single.html
+++ b/layouts/organizers/single.html
@@ -12,7 +12,9 @@
 {{- end -}}
 {{- $posts := where (where site.RegularPages "Section" "blog") "Params.authors" "intersect" (slice $slug) -}}
 
-{{ partial "page-hero.html" (dict "eyebrow" (.Params.role | default "Host") "title" .Title) }}
+{{- /* Theme 0.7.0 back link, with our own label: the theme string for this
+       section says "All organizers", and we call them hosts. */ -}}
+{{ partial "page-hero.html" (dict "eyebrow" (.Params.role | default "Host") "title" .Title "backHref" (print (partial "section.html" "team") "/") "backLabel" "All hosts") }}
 
 <section class="g-bg-ink">
   <div class="g-container g-stats">

--- a/layouts/speakers/single.html
+++ b/layouts/speakers/single.html
@@ -4,7 +4,7 @@
        pages repeat the bio as body text), so render it once in the persona
        card, and list the speaker's episodes instead of the theme's
        events-based sessions. */ -}}
-{{ partial "page-hero.html" (dict "eyebrow" (.Params.eyebrow | default "Speaker") "title" .Title) }}
+{{ partial "page-hero.html" (dict "eyebrow" (.Params.eyebrow | default "Speaker") "title" .Title "backHref" "speakers/" "backLabel" (i18n "allSpeakers")) }}
 <section class="g-bg-white g-section">
   <div class="g-container">
     <div class="g-article" style="margin-bottom:var(--space-5)">


### PR DESCRIPTION
Bumps the `themes/popular` submodule from v0.6.0 to [v0.7.0](https://github.com/Mariatta/hugo-theme-popular/releases/tag/v0.7.0) and pulls in the parts of that release that fit a podcast site.

Most of v0.7.0 is meetup machinery we do not use: the iCalendar feed, venue access and logistics fields, the talk archive, and the community-chat CTA. The "no upcoming events" empty-state fix does not apply either, since we have no events section. On its own, the upgrade changes exactly one thing in our rendered HTML: the footer gains a theme version badge.

## What this adopts

**Profile back links.** v0.7.0 adds a back link to the hero on speaker and organizer profiles. Both templates are our own forks, so the change does not reach us automatically; this adds it by hand. Hosts get "All hosts" instead of the theme string "All organizers".

**`/llms.txt`.** A plain-text summary for AI agents, new in v0.7.0. The theme's template is meetup-shaped: on this site it emitted "No upcoming events are scheduled right now.", an `Events:` line with no URL, and a link to an `/events/calendar.ics` we do not generate. `layouts/index.llms.txt` overrides it with the show instead:

```
# Hidden Figures of Python Podcast

Hidden Figures of Python is a podcast series by the PyPodcats team, ...

Latest episode: Episode 12: with Juanita Gomez, published July 17, 2026 (https://pypodcats.live/episodes/ep-12/)

## Listen and follow
Apple Podcasts: ...
Spotify: ...
YouTube: ...
Mastodon: ...
RSS: https://pypodcats.live/episodes/index.xml

## Recent episodes
- Episode 12: with Juanita Gomez, July 17, 2026 (https://pypodcats.live/episodes/ep-12/)
- Episode 11: with Sheena O'Connell, February 26, 2026 (...)
...

## Links
All episodes / Guests / Hosts / Blog / About and FAQ / Subscribe / Contact
```

Trailers are excluded, the platform links come from `[[social]]`, and it is regenerated on every build so the latest-episode line stays true.

**Footer version badge off.** v0.7.0 prints the theme version next to the Popular credit whenever the credit points at mariatta.ca, which ours does. Setting `popularVersion = ""` in our params keeps the footer as it was, without forking the footer partial.

## Not in this PR

Available now with no further work, whenever we want them: the recap toolkit (`gallery` / `photo` / `pullquote` shortcodes, `alt` required or the build fails), the site-wide notice banner (`params.notice`), and the "Your name here?" speaker invite card (would need a guest-pitch page at `/speak/`).

## Testing

`hugo --gc` builds clean. Verified in the generated output: back links render on `/speakers/<guest>/` and `/hosts/<host>/`, `/llms.txt` is correct, and the footer shows the credit with no version badge. Diffing the full site build against v0.6.0 confirmed the version badge was the only other change.