### PR TITLE
Update the Popular theme to v0.10.0

### DIFF
--- a/layouts/_default/episode.html
+++ b/layouts/_default/episode.html
@@ -30,11 +30,11 @@
     <div class="g-card" style="margin-bottom:var(--space-4)">
       <div class="g-card__body" style="display:flex;gap:var(--space-3);align-items:center;flex-wrap:wrap">
         {{ with .Params.episode_image }}
-          <img src="{{ . | relURL }}" alt="{{ $.Title }}" style="width:120px;height:120px;object-fit:cover;border-radius:var(--radius-md);flex-shrink:0">
+          <img src="{{ partial "rel-src.html" . }}" alt="{{ $.Title }}" style="width:120px;height:120px;object-fit:cover;border-radius:var(--radius-md);flex-shrink:0">
         {{ end }}
         <div style="flex:1;min-width:16rem">
           <audio controls preload="metadata" style="width:100%">
-            <source src="{{ .Params.podcast_file | relURL }}" type="audio/mpeg">
+            <source src="{{ partial "rel-src.html" .Params.podcast_file }}" type="audio/mpeg">
           </audio>
           <div class="g-row" style="margin-top:.6rem">{{ partial "podcast-platforms.html" . }}</div>
         </div>
@@ -57,7 +57,7 @@
     {{ with .Params.speaker }}
       <h2 style="font-size:var(--text-xl);margin:var(--space-5) 0 1rem">Get to know {{ .title }}</h2>
       <div class="g-persona g-persona--primary">
-        {{ with .image }}<img class="g-persona__img" src="{{ . | relURL }}" alt="{{ $.Params.speaker.title }}">{{ end }}
+        {{ with .image }}<img class="g-persona__img" src="{{ partial "rel-src.html" . }}" alt="{{ $.Params.speaker.title }}">{{ end }}
         <div>
           <div class="g-persona__name"><a href="{{ .url | relLangURL }}" style="color:inherit">{{ .title }}</a></div>
           {{ with .description }}<p class="g-persona__bio">{{ . }}</p>{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,7 +20,7 @@
         </div>
       {{ end }}
     </div>
-    {{ with .image }}<div class="g-hero__media"><img src="{{ . | relURL }}" alt="{{ site.Title }}"></div>{{ end }}
+    {{ with .image }}<div class="g-hero__media"><img src="{{ partial "rel-src.html" . }}" alt="{{ site.Title }}"></div>{{ end }}
   </div>
 </section>
 {{ end }}
@@ -61,7 +61,7 @@
 {{- range (first 1 $upcoming) }}
 <section class="g-bg-wash-soft">
   <div class="g-container g-feature">
-    {{ with .Params.image | default site.Params.ogImage }}<div class="g-feature__media"><img src="{{ . | relURL }}" alt="{{ $.Title }}"></div>{{ end }}
+    {{ with .Params.image | default site.Params.ogImage }}<div class="g-feature__media"><img src="{{ partial "rel-src.html" . }}" alt="{{ $.Title }}"></div>{{ end }}
     <div class="g-feature__body">
       <span class="g-badge g-badge--soft"><i class="fa-solid fa-calendar" aria-hidden="true"></i> {{ i18n "nextMeetup" }}</span>
       <h2 style="margin:0">{{ .Title }}</h2>
@@ -130,7 +130,7 @@
       <figure class="g-quote">
         <blockquote>{{ $t.quote }}</blockquote>
         <figcaption>
-          {{ with $t.photo }}<img src="{{ . | relURL }}" alt="{{ $t.name }}">{{ end }}
+          {{ with $t.photo }}<img src="{{ partial "rel-src.html" . }}" alt="{{ $t.name }}">{{ end }}
           <div><span class="g-quote__name">{{ $t.name }}</span>{{ with $t.role }}<span class="g-quote__role">{{ . }}</span>{{ end }}</div>
         </figcaption>
       </figure>

--- a/layouts/partials/episode-card.html
+++ b/layouts/partials/episode-card.html
@@ -2,7 +2,7 @@
        PyPodcats podcast layer on top of the Popular theme. */ -}}
 <article class="g-card" data-tags="{{ with .Params.tags }}{{ delimit . "," }}{{ end }}">
   {{ with .Params.episode_image }}
-    <a href="{{ $.RelPermalink }}" class="g-card__media"><img src="{{ . | relURL }}" alt="{{ $.Title }}" loading="lazy"></a>
+    <a href="{{ $.RelPermalink }}" class="g-card__media"><img src="{{ partial "rel-src.html" . }}" alt="{{ $.Title }}" loading="lazy"></a>
   {{ end }}
   <div class="g-card__body">
     <span class="g-card__eyebrow">

--- a/layouts/partials/jsonld-podcast-episode.html
+++ b/layouts/partials/jsonld-podcast-episode.html
@@ -14,10 +14,10 @@
   {{- $actors = $actors | append (dict "@type" "Person" "name" $full) -}}
 {{- end -}}
 
-{{- $series := dict "@type" "PodcastSeries" "name" site.Title "url" (absURL "/") -}}
+{{- $series := dict "@type" "PodcastSeries" "name" site.Title "url" (partial "abs-url.html" "/") -}}
 
 {{- /* AudioObject: contentUrl is required for a valid enclosure. */ -}}
-{{- $audio := dict "@type" "AudioObject" "contentUrl" (.Params.podcast_file | absURL) "encodingFormat" "audio/mpeg" -}}
+{{- $audio := dict "@type" "AudioObject" "contentUrl" (partial "abs-url.html" .Params.podcast_file) "encodingFormat" "audio/mpeg" -}}
 {{- with .Params.podcast_bytes }}{{ $audio = merge $audio (dict "contentSize" (printf "%v" .)) }}{{ end -}}
 
 {{- $ld := dict
@@ -50,5 +50,5 @@
 {{- end -}}
 
 {{- $img := .Params.episode_image | default .Params.image | default site.Params.ogImage -}}
-{{- with $img }}{{ $ld = merge $ld (dict "image" (. | absURL)) }}{{ end -}}
+{{- with $img }}{{ $ld = merge $ld (dict "image" (partial "abs-url.html" .)) }}{{ end -}}
 <script type="application/ld+json">{{ $ld | jsonify | safeJS }}</script>

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -21,7 +21,7 @@
 {{- end }}
 {{- /* Site override: episodes carry their art in episode_image. */ -}}
 {{- $img := .Params.image | default .Params.episode_image | default site.Params.ogImage -}}
-{{ with $img }}<meta property="og:image" content="{{ . | absURL }}">
+{{ with $img }}<meta property="og:image" content="{{ partial "abs-url.html" . }}">
 <meta property="og:image:alt" content="{{ $.Params.imageAlt | default $.Title }}">{{ end }}
 <meta name="twitter:card" content="{{ if $img }}summary_large_image{{ else }}summary{{ end }}">
 {{ with .OutputFormats.Get "RSS" }}<link rel="alternate" type="application/rss+xml" href="{{ .RelPermalink }}" title="{{ site.Title }}">{{ end }}


### PR DESCRIPTION
Theme v0.7.0 -> v0.10.0. Rendered output on this site is unchanged: I built the
site with each version and diffed every generated page, and the only differences
are the asset fingerprint hashes (plus one blank line where the new, inactive
preview-bar partial sits). No markup changes anywhere.

## What landed upstream that we do not consume

The bulk of 0.8-0.10 is tooling in the theme repo: a setup wizard
(`scripts/setup.py`, `starter-content.py`), an Astro npm-package model, demo
build scripts, and a preview banner for tools that render a site on someone's
behalf and show it in an iframe. The banner is opt-in through
`params.previewMode`, which nothing here sets, so it stays off.

## What does reach us

- **v0.9.0's base-aware URL helpers.** `rel-src.html` (images and assets) and
  `abs-url.html` (absolute URLs) join the existing `rel-href.html`, and the
  theme now routes every URL it emits through them so a subpath deployment
  keeps working. Our forked templates do not pick that up automatically, so the
  podcast layer adopts the helpers too: episode art, speaker photos, the audio
  enclosure, `og:image` and the PodcastEpisode JSON-LD. We serve from a domain
  root, so this changes nothing today, it keeps the forks in step with the
  theme they are forked from.
- The docs sidebar scroll fix and the two new preview i18n strings, neither of
  which this site renders.

The theme's `min_version` is 0.146.0, so the Hugo 0.147.8 pinned in
`.tool-versions` still clears the floor.